### PR TITLE
2.5.0 beta.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Core-module for related "normalized-db"-libraries providing common models and ut
 functions as well as the `Schema` (implemented with `TypeScript`).
 
  - **Author**: Sandro Schmid ([saseb.schmid@gmail.com](<mailto:saseb.schmid@gmail.com>))
- - **Version**: 2.5.0-beta.2
+ - **Version**: 2.5.0-beta.3
 
 ## Versioning
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@normalized-db/core",
-  "version": "2.5.0-beta.2",
+  "version": "2.5.0-beta.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@normalized-db/core",
-  "version": "2.5.0-beta.2",
+  "version": "2.5.0-beta.3",
   "author": "Sandro Schmid <saseb.schmid@gmail.com>",
   "license": "MIT",
   "description": "Core-module for related 'normalized-db'-libraries providing common models and utility functions as well as the `Schema` (implemented with `TypeScript`).",

--- a/src/model/log-mode.enum.ts
+++ b/src/model/log-mode.enum.ts
@@ -1,5 +1,5 @@
 export enum LogMode {
-  Disabled = 0, // disable logging
-  Simple = 1, // `LogEntry<?>` except `item`-field
-  Full = 2 // include `item`-field
+  Disabled = 'disabled', // disable logging
+  Simple = 'simple', // `LogEntry<?>` except `item`-field
+  Full = 'full' // include `item`-field
 }

--- a/src/schema/schema-log-config.ts
+++ b/src/schema/schema-log-config.ts
@@ -1,4 +1,5 @@
 import { EventType, ILogConfig, LogMode, ValidKey } from '../model';
+import { isNull } from '../utility/object';
 import { StoreLogBuilder } from './builder/store-log-builder';
 import { IStoreLogConfig } from './model/store-log-config-interface';
 import { ISchema } from './schema-interface';
@@ -51,7 +52,7 @@ export class SchemaLogConfig implements ILogConfig {
             : logConfig.eventSelection === eventType;
       }
 
-      if (isEnabled && key && logConfig.keys && logConfig.keys.length > 0) {
+      if (isEnabled && !isNull(key) && logConfig.keys && logConfig.keys.length > 0) {
         isEnabled = logConfig.keys.indexOf(key) >= 0;
       }
     }


### PR DESCRIPTION
* Use strings as enum-values
* Use `isNull` for checking availability of `key`-arg